### PR TITLE
Fix WebView provider injection on Android 15+ / 16

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdk 35
+    compileSdk 36
     defaultConfig {
         applicationId "com.thinkdifferent.anywebview"
         minSdk 24
-        targetSdk 35
-        versionCode 4
-        versionName '1.3'
+        targetSdk 36
+        versionCode 5
+        versionName '1.4'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/src/main/java/com/thinkdifferent/anywebview/AnyWebView.java
+++ b/app/src/main/java/com/thinkdifferent/anywebview/AnyWebView.java
@@ -1,17 +1,14 @@
 package com.thinkdifferent.anywebview;
 
-import static com.thinkdifferent.anywebview.XposedHelpersWraper.findAndHookConstructor;
 import static com.thinkdifferent.anywebview.XposedHelpersWraper.findAndHookMethod;
 import static com.thinkdifferent.anywebview.XposedHelpersWraper.findClass;
 import static com.thinkdifferent.anywebview.XposedHelpersWraper.findConstructorBestMatch;
-import static com.thinkdifferent.anywebview.XposedHelpersWraper.findField;
-import static com.thinkdifferent.anywebview.XposedHelpersWraper.findFirstFieldByExactType;
-import static com.thinkdifferent.anywebview.XposedHelpersWraper.findMethodExact;
+import static com.thinkdifferent.anywebview.XposedHelpersWraper.getObjectField;
 import static com.thinkdifferent.anywebview.XposedHelpersWraper.log;
 
+import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
-import android.os.Build;
 import android.os.Bundle;
 import android.util.Base64;
 
@@ -20,11 +17,9 @@ import java.io.InputStream;
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import de.robv.android.xposed.XC_MethodHook;
@@ -38,121 +33,180 @@ public class AnyWebView extends BaseXposedHookLoadPackage {
         if (lpparam.packageName.equals("android")) {
             Initialize initialize = new Initialize(lpparam).invoke();
             Class<?> classWebViewProviderInfo = initialize.getClassWebViewProviderInfo();
-            Class<?> classWebViewProviderInfoArray = initialize.getClassWebViewProviderInfoArray();
             Class<?> classSystemImpl = initialize.getClassSystemImpl();
-            Class<?> classWebViewUpdater = initialize.getClassWebViewUpdater();
             Constructor<?> constructorWebViewProviderInfo = initialize.getConstructorWebViewProviderInfo();
 
-            Class<?> classSystemServer = findClass("com.android.server.SystemServer", lpparam.classLoader);
-            Field mPackageManager = findField(classSystemServer, "mPackageManager");
-            mPackageManager.setAccessible(true);
-            final PackageManager[] mPm = new PackageManager[1];
-            Class<?> classComtextImpl = findClass("android.app.ContextImpl", lpparam.classLoader);
-            final boolean[] findFlag = new boolean[]{false};
-            findAndHookMethod(classComtextImpl, "getPackageManager", new XC_MethodHook() {
+            // getWebViewPackages() is called repeatedly (provider selection, package-change
+            // handling, shell commands). Enumerating every installed package on each call would
+            // run a full PackageManager sweep in system_server, so the appended entries are
+            // computed once and reused.
+            final Object[] extraProvidersCache = new Object[1];
+
+            findAndHookMethod(classSystemImpl, "getWebViewPackages", new XC_MethodHook() {
                 @Override
                 protected void afterHookedMethod(MethodHookParam param) {
-                    StackTraceElement[] stackTrace = new Throwable().getStackTrace();
-                    // TODO Need a better filter condition or determination logic to get a PackageManager Object with privilege permission
-                    //  instead of (stackTrace.length<=20;i<=5)
-                    if (!findFlag[0] && stackTrace.length <= 20) {
-                        log("enumerate method");
-                        for (int i = 0; i < stackTrace.length && i <= 5; i++) {
-                            StackTraceElement ste = stackTrace[i];
-                            if (ste.getMethodName().equals("startBootstrapServices")) {
-                                log("setting mPm");
-                                mPm[0] = (PackageManager) param.getResult();
-                                findFlag[0] = true;
-                                break;
-                            }
-                        }
-                        log(Arrays.toString(stackTrace));
-                    }
-                }
-            });
-
-            Method getInstalledPackages = findMethodExact(PackageManager.class, "getInstalledPackages", int.class);
-
-            findAndHookConstructor(classSystemImpl, new XC_MethodHook() {
-                @Override
-                protected void beforeHookedMethod(MethodHookParam param) {
                     try {
-                        log("installedPackageInfoList");
-                        List<PackageInfo> installedPackageInfoList = (ArrayList<PackageInfo>) getInstalledPackages.invoke(mPm[0], PackageManager.MATCH_ALL | PackageManager.GET_META_DATA | PackageManager.GET_SIGNATURES);
-                        if (installedPackageInfoList == null) {
-                            log("installedPackageInfoList is null");
-                        } else {
-                            log("installedPackageInfoList length:" + installedPackageInfoList.toArray().length);
+                        Object stockProviders = param.getResult();
+                        if (stockProviders == null) {
+                            return;
                         }
-                        List<String> webviewPkgNameList = new ArrayList<>();
-                        List<String> webviewLabelList = new ArrayList<>();
-                        List<String[]> webviewSignaturesList = new ArrayList<>();
-                        for (PackageInfo packageInfo : installedPackageInfoList) {
-                            Bundle metaData = packageInfo.applicationInfo.metaData;
-                            if (metaData == null) {
-                                continue;
+                        int stockLen = Array.getLength(stockProviders);
+                        if (extraProvidersCache[0] == null) {
+                            Context context = findSystemContext(param.thisObject, lpparam.classLoader);
+                            if (context == null) {
+                                log("no system Context, leaving provider list untouched");
+                                return;
                             }
-                            String awLib = metaData.getString("com.android.webview.WebViewLibrary");
-                            if (awLib != null && awLib.length() > 0) {
-                                webviewPkgNameList.add(packageInfo.packageName);
-                                webviewLabelList.add(mPm[0].getApplicationLabel(packageInfo.applicationInfo).toString());
-                                int signsLen = packageInfo.signatures.length;
-                                log("signsLen:" + signsLen);
-                                String[] signatures = new String[signsLen];
-                                for (int i = 0; i < signsLen; i++) {
-                                    byte[] rawCert = packageInfo.signatures[i].toByteArray();
-                                    InputStream certStream = new ByteArrayInputStream(rawCert);
-                                    CertificateFactory certFactory = CertificateFactory.getInstance("X509");
-                                    X509Certificate x509Cert = (X509Certificate) certFactory.generateCertificate(certStream);
-                                    signatures[i] = Base64.encodeToString(x509Cert.getEncoded(), Base64.DEFAULT);
-
-                                }
-                                webviewSignaturesList.add(signatures);
+                            PackageManager pm = context.getPackageManager();
+                            if (pm == null) {
+                                log("no PackageManager, leaving provider list untouched");
+                                return;
                             }
+                            extraProvidersCache[0] = buildExtraProviders(
+                                    stockProviders, stockLen, pm,
+                                    classWebViewProviderInfo, constructorWebViewProviderInfo);
                         }
-                        log("webviewPkgNameList:" + webviewPkgNameList.toString());
-                        log("webviewLabelList:" + webviewLabelList.toString());
-                        log("webviewSignaturesList:");
-                        for (String[] sarr : webviewSignaturesList) {
-                            log("sarr len:" + sarr.length);
-                            for (String s : sarr) {
-                                log("sign:" + s);
-                            }
+                        Object extraProviders = extraProvidersCache[0];
+                        int extraLen = Array.getLength(extraProviders);
+                        if (extraLen == 0) {
+                            return;
                         }
 
-                        int size = webviewPkgNameList.size();
-                        Object webViewProviders = Array.newInstance(classWebViewProviderInfo, size);
-                        for (int i = 0; i < size; i++) {
-                            Array.set(webViewProviders, i, constructorWebViewProviderInfo.newInstance(webviewPkgNameList.get(i), webviewLabelList.get(i), true, false, webviewSignaturesList.get(i)));
-                        }
-
-                        Field mWebViewProviderPackages = findFirstFieldByExactType(classSystemImpl, classWebViewProviderInfoArray);
-                        mWebViewProviderPackages.setAccessible(true);
-                        mWebViewProviderPackages.set(param.thisObject, webViewProviders);
-                        param.setResult(param.thisObject);
+                        Object merged = Array.newInstance(classWebViewProviderInfo, stockLen + extraLen);
+                        System.arraycopy(stockProviders, 0, merged, 0, stockLen);
+                        System.arraycopy(extraProviders, 0, merged, stockLen, extraLen);
+                        log("appended " + extraLen + " provider(s) to " + stockLen + " stock entries");
+                        param.setResult(merged);
                     } catch (Throwable t) {
                         log(t);
                     }
                 }
             });
-            // Disable signature validity check
-            /*if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                findAndHookMethod(classWebViewUpdater, "validityResult", classWebViewProviderInfo, PackageInfo.class, new XC_MethodHook() {
-                    @Override
-                    protected void beforeHookedMethod(MethodHookParam param) {
-                        param.setResult(*//*VALIDITY_OK*//*0);
-                    }
-                });
-            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                findAndHookMethod(classWebViewUpdater, "isValidProvider", classWebViewProviderInfo, PackageInfo.class, new XC_MethodHook() {
-                    @Override
-                    protected void beforeHookedMethod(MethodHookParam param) {
-                        param.setResult(true);
-                    }
-                });
-            }*/
         }
     }
+
+    /**
+     * Resolves a system_server Context, which yields a PackageManager privileged enough to
+     * enumerate every installed package with signatures.
+     *
+     * On Android 15+ WebViewUpdateService constructs SystemImpl per service and it holds the
+     * Context in mContext, so the receiver is the most direct source and is exactly the
+     * PackageManager SystemImpl itself uses in getPackageInfoForProvider(). On API 24-34
+     * SystemImpl is a LazyHolder singleton with a no-arg constructor and no Context field at all
+     * (its SystemInterface methods take a Context parameter instead), so fall back to
+     * system_server's own ActivityThread, which is present on every release.
+     */
+    private static Context findSystemContext(Object systemImpl, ClassLoader classLoader) {
+        try {
+            Field field = systemImpl.getClass().getDeclaredField("mContext");
+            field.setAccessible(true);
+            Context context = (Context) field.get(systemImpl);
+            if (context != null) {
+                return context;
+            }
+        } catch (NoSuchFieldException expectedOnOlderReleases) {
+            // Pre-Android-15 SystemImpl has no Context field; handled by the fallback below.
+        } catch (Throwable t) {
+            log(t);
+        }
+        try {
+            Class<?> classActivityThread = Class.forName(
+                    "android.app.ActivityThread", false, classLoader);
+            Object activityThread = classActivityThread.getMethod("currentActivityThread")
+                    .invoke(null);
+            if (activityThread != null) {
+                return (Context) classActivityThread.getMethod("getSystemContext")
+                        .invoke(activityThread);
+            }
+        } catch (Throwable t) {
+            log(t);
+        }
+        return null;
+    }
+
+    /**
+     * Builds the WebViewProviderInfo[] to append: every installed package declaring
+     * com.android.webview.WebViewLibrary meta-data that is not already in the stock list.
+     *
+     * Packages without that meta-data are skipped because validityResult() rejects them with
+     * VALIDITY_NO_LIBRARY_FLAG regardless, so including them would only cost a PackageManager
+     * lookup each. Entries are marked availableByDefault so provider selection considers them,
+     * and carry their own signature so providerHasValidSignature() passes without relying on a
+     * debuggable build. Actual suitability is still decided downstream by validityResult().
+     */
+    private static Object buildExtraProviders(Object stockProviders, int stockLen,
+                                              PackageManager pm,
+                                              Class<?> classWebViewProviderInfo,
+                                              Constructor<?> constructorWebViewProviderInfo) throws Exception {
+        List<String> stockPkgNames = new ArrayList<>();
+        for (int i = 0; i < stockLen; i++) {
+            Object provider = Array.get(stockProviders, i);
+            stockPkgNames.add((String) getObjectField(provider, "packageName"));
+        }
+        log("stock providers:" + stockPkgNames);
+
+        List<PackageInfo> installedPackageInfoList = pm.getInstalledPackages(
+                PackageManager.MATCH_ALL | PackageManager.GET_META_DATA | PackageManager.GET_SIGNATURES);
+        if (installedPackageInfoList == null) {
+            log("installedPackageInfoList is null");
+            return Array.newInstance(classWebViewProviderInfo, 0);
+        }
+        log("installedPackageInfoList length:" + installedPackageInfoList.size());
+
+        List<Object> extras = new ArrayList<>();
+        for (PackageInfo packageInfo : installedPackageInfoList) {
+            if (packageInfo.applicationInfo == null) {
+                continue;
+            }
+            Bundle metaData = packageInfo.applicationInfo.metaData;
+            if (metaData == null) {
+                continue;
+            }
+            String awLib = metaData.getString("com.android.webview.WebViewLibrary");
+            if (awLib == null || awLib.isEmpty()) {
+                continue;
+            }
+            if (stockPkgNames.contains(packageInfo.packageName)) {
+                log("skipping already-declared provider:" + packageInfo.packageName);
+                continue;
+            }
+            if (packageInfo.signatures == null || packageInfo.signatures.length == 0) {
+                log("skipping unsigned provider:" + packageInfo.packageName);
+                continue;
+            }
+
+            String label = pm.getApplicationLabel(packageInfo.applicationInfo).toString();
+            String[] signatures = encodeSignatures(packageInfo);
+            log("adding provider:" + packageInfo.packageName + " label:" + label
+                    + " signatures:" + signatures.length);
+            extras.add(constructorWebViewProviderInfo.newInstance(
+                    packageInfo.packageName, label,
+                    /*availableByDefault*/ true, /*isFallback*/ false, signatures));
+        }
+
+        Object result = Array.newInstance(classWebViewProviderInfo, extras.size());
+        for (int i = 0; i < extras.size(); i++) {
+            Array.set(result, i, extras.get(i));
+        }
+        return result;
+    }
+
+    /**
+     * WebViewProviderInfo takes base64-encoded DER certificates, matching the format the
+     * framework parses out of config_webview_packages.xml.
+     */
+    private static String[] encodeSignatures(PackageInfo packageInfo) throws Exception {
+        int signsLen = packageInfo.signatures.length;
+        String[] signatures = new String[signsLen];
+        CertificateFactory certFactory = CertificateFactory.getInstance("X509");
+        for (int i = 0; i < signsLen; i++) {
+            InputStream certStream = new ByteArrayInputStream(packageInfo.signatures[i].toByteArray());
+            X509Certificate x509Cert = (X509Certificate) certFactory.generateCertificate(certStream);
+            signatures[i] = Base64.encodeToString(x509Cert.getEncoded(), Base64.NO_WRAP);
+        }
+        return signatures;
+    }
+
 
     @Override
     public void initZygote(StartupParam startupParam) {
@@ -161,9 +215,7 @@ public class AnyWebView extends BaseXposedHookLoadPackage {
     private static class Initialize {
         private XC_LoadPackage.LoadPackageParam lpparam;
         private Class<?> classWebViewProviderInfo;
-        private Class<?> classWebViewProviderInfoArray;
         private Class<?> classSystemImpl;
-        private Class<?> classWebViewUpdater;
         private Constructor<?> constructorWebViewProviderInfo;
 
         public Initialize(XC_LoadPackage.LoadPackageParam lpparam) {
@@ -174,16 +226,8 @@ public class AnyWebView extends BaseXposedHookLoadPackage {
             return classWebViewProviderInfo;
         }
 
-        public Class<?> getClassWebViewProviderInfoArray() {
-            return classWebViewProviderInfoArray;
-        }
-
         public Class<?> getClassSystemImpl() {
             return classSystemImpl;
-        }
-
-        public Class<?> getClassWebViewUpdater() {
-            return classWebViewUpdater;
         }
 
         public Constructor<?> getConstructorWebViewProviderInfo() {
@@ -200,17 +244,7 @@ public class AnyWebView extends BaseXposedHookLoadPackage {
                     /*description*/String.class,/*TAG_AVAILABILITY*/boolean.class,
                     /*TAG_FALLBACK*/boolean.class,/*readSignatures*/String[].class);
 
-            classWebViewProviderInfoArray = findClass(
-                    "[Landroid.webkit.WebViewProviderInfo;", lpparam.classLoader);
             classSystemImpl = findClass("com.android.server.webkit.SystemImpl", lpparam.classLoader);
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                classWebViewUpdater = findClass("com.android.server.webkit.WebViewUpdateServiceImpl", lpparam.classLoader);
-            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                classWebViewUpdater = findClass("com.android.server.webkit.WebViewUpdater", lpparam.classLoader);
-            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                classWebViewUpdater = findClass("com.android.server.webkit.WebViewUpdateServiceImpl$WebViewUpdater", lpparam.classLoader);
-            }
 
             return this;
         }


### PR DESCRIPTION
# This PR was vibe coded, but an human tested what it could. Feels free to close this if this is too much a burden to review. See bottom to know what was really tested

The module no longer works on API 35+. This fixes it, and reworks the injection
point to match how `WebViewUpdateService` is built on current AOSP.

**Three defects, all on API 35+:**

1. `Initialize.invoke()` resolved `WebViewUpdateServiceImpl`, which Android 15
   renamed to `WebViewUpdateServiceImpl2`. `findClass()` threw
   `ClassNotFoundError` and aborted before any hook was installed.
2. The `SystemImpl` constructor hook skipped the constructor body, which on
   Android 15+ leaves `mContext` null and NPEs the whole `SystemInterface`.
3. The `ContextImpl.getPackageManager` hook identified a privileged
   `PackageManager` by scanning stack frames; it never matched, so nothing was
   enumerated and it stack-dumped on every call for the life of the boot.

**Fix:** hook `SystemImpl.getWebViewPackages()` and *append* to its result, so
the framework's own `validityResult()` decides what is usable. Two hooks become
one, and the stack-scanning heuristic is gone. `minSdk` stays 24.

**Verified on Android 16 (API 36):** the added provider is enumerated, reported
`Valid`, and selectable, with the stock provider still listed and no bootloop.

### Not tested

**The API 24-34 fallback path has not been executed on a device.** It is derived
from the AOSP sources for 7.0 / 10 / 13 / 14, compiles, and passes lint, but on
Android 15+ it is dead code by design — the `mContext` read succeeds first, so
the Android 16 testing never exercised it. If anyone has a pre-15 device or
emulator handy, that is the remaining gap.

I can't run a emulator for the next 2 weeks to test previous versions because of storage, but should be fine

### Also included

- `compileSdk` / `targetSdk` raised to 36.
- Version bumped to 1.4 (`versionCode` 5).

### Known limitation

The appended entries are cached on the first `getWebViewPackages()` call, so a
WebView provider **installed after boot is not picked up until reboot**.

The tradeoff is deliberate: without the cache, every `packageStateChanged` event
triggers a full `getInstalledPackages()` sweep inside system_server. A middle
ground would be to invalidate the cache only from `packageStateChanged`, so
installs are seen live while routine calls stay cheap. Happy to add that if
preferred.

<details>
<summary><b>Details:</b> problems, approach, compatibility, test output</summary>

## Problems

### 1. `ClassNotFoundError` aborts the hook on API 35+

`Initialize.invoke()` resolved `com.android.server.webkit.WebViewUpdateServiceImpl`
unconditionally on SDK >= S. Android 15 renamed that class to
`WebViewUpdateServiceImpl2`, so `findClass()` threw:

```
E anywebview: XposedHelpers$ClassNotFoundError:
    java.lang.ClassNotFoundException:
    com.android.server.webkit.WebViewUpdateServiceImpl
```

That aborted `invoke()` before `handleLoadPackage()` could install the provider
hook, so nothing was injected at all.

The field was already dead: `classWebViewUpdater` was write-only, and its only
reader `getClassWebViewUpdater()` had its result discarded at the call site. It
was scaffolding for the `validityResult` / `isValidProvider` hooks, which are
commented out. Removed.

### 2. The `SystemImpl` constructor hook left `mContext` null

The old hook wrote `mWebViewProviderPackages` reflectively and then skipped the
constructor body with `setResult(param.thisObject)`.

Android 15 reworked `SystemImpl` from a `LazyHolder` singleton into a
per-service instance that stores the system_server `Context` in `mContext` and
assigns `mWebViewProviderPackages` as a `final` field. Skipping the constructor
therefore left `mContext` null, and every `SystemInterface` method that needs it
would NPE once provider validation ran:

| `SystemImpl` (AOSP main) | uses `mContext` |
|---|---|
| `getPackageInfoForProvider` | yes |
| `getPackageInfoForProviderAllUsers` | yes |
| `getFactoryPackageVersion` | yes |
| `getSettingsString` / `updateUserSetting` | yes |
| `getUserManager` / `createContextAsUser` paths | yes |

It also meant reflectively writing a `final` field.

### 3. The `ContextImpl.getPackageManager` hook never matched

It tried to identify a privileged `PackageManager` by scanning the first six
stack frames for `startBootstrapServices`:

```java
if (!findFlag[0] && stackTrace.length <= 20) {
    for (int i = 0; i < stackTrace.length && i <= 5; i++) { ... }
}
```

Under Xposed implementations that insert frames of their own, the real caller
sits well past index 5, so the flag never latched. Two consequences:

- `mPm` stayed null, so nothing could be enumerated.
- Because the flag never latched, the hook ran `new Throwable().getStackTrace()`
  plus a full `Arrays.toString()` dump on **every** `getPackageManager()` call in
  system_server, for the entire life of the boot.

This was the pre-existing `TODO` in that block.

## Approach

Hook `SystemImpl.getWebViewPackages()` and **append** to its result, instead of
hooking the constructor.

`getWebViewPackages()` just returns the array; the filtering happens downstream
in `getValidWebViewPackagesAndInfos()`, which calls `getPackageInfoForProvider()`
then `validityResult()` per entry. So widening the returned list lets the
framework's own validation decide what is usable — no need to disable any check.

Consequences:

- The constructor runs untouched, so `mContext` is populated.
- Nothing writes a `final` field.
- Appending preserves the stock entry, which keeps
  `WebViewUpdateServiceImpl2`'s `"No available by default WebView Provider."`
  `AndroidRuntimeException` unreachable. Replacing the array risks a bootloop.

Injected entries:

- **Filtered** to packages declaring `com.android.webview.WebViewLibrary`
  metadata. Anything else returns `VALIDITY_NO_LIBRARY_FLAG` regardless, so
  including it would only cost a `PackageManager` lookup per package during boot.
- **Carry their own base64 signature**, so `providerHasValidSignature()` passes
  without depending on `systemIsDebuggable()`.
- **Marked `availableByDefault`**, so provider selection considers them.
- **Cached**, since `getWebViewPackages()` is called on every package change.

The `Context` now comes from `SystemImpl.mContext` where it exists (Android 15+),
falling back to `ActivityThread.getSystemContext()`. That fallback covers
API 24-34, where `SystemImpl` is a `LazyHolder` singleton with a no-arg
constructor and no `Context` field at all (its `SystemInterface` methods take a
`Context` parameter instead).

Net effect: two hooks become one, and the stack-scanning heuristic is gone.

## Compatibility

`minSdk` is unchanged at 24. Checked against AOSP sources per release:

| API | `SystemImpl` shape | `mContext` field | Context source used |
|---|---|---|---|
| 24-34 (7.0-14) | `LazyHolder` singleton, `private SystemImpl()` | absent | `ActivityThread.getSystemContext()` |
| 35-36 (15, 16) | per-service instance, `SystemImpl(Context)` | present | `SystemImpl.mContext` |

Also verified stable across 24 -> 36:

- `WebViewProviderInfo(String, String, boolean, boolean, String[])` constructor
- `SystemImpl.getWebViewPackages()`

Every API used is at or below minSdk 24 (`MATCH_ALL` is the newest, API 23).
`lintVitalRelease` passes, which runs the `NewApi` check.

## Test output

Verified on Android 16 (API 36), rooted, module active.

Before:

```
WebView packages:
  Valid package com.google.android.webview (...) is installed/enabled for all users
  com.google.android.webview.beta is NOT installed.
  ...
```

The target provider was installed but absent from the list entirely.

After:

```
Current WebView package (name, version): (app.mihon.webview, 145.0.7632.122)
WebView packages:
  Valid package com.google.android.webview (versionCode: 787104603, targetSdkVersion: 36) is installed/enabled for all users
  ...
  Valid package app.mihon.webview (versionCode: 763212231, targetSdkVersion: 36) is installed/enabled for all users
```

```
D anywebview: appended 1 provider(s) to 6 stock entries
```

- Provider enumerated, reported `Valid` by the framework's own validation, and
  selectable.
- Stock provider still listed.
- `cmd webviewupdate set-webview-implementation app.mihon.webview` returns
  `Success`.
- No bootloop, no exceptions.
- Module log output for a whole boot went from an unbounded per-call stack dump
  down to a few lines.

</details>
