### PR TITLE
fix(webview): inject providers via getWebViewPackages for android 15+

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,5 +31,9 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+    // Both APIs are compileOnly: the frameworks provide them at runtime, and keeping the
+    // libxposed AAR off the runtime graph also keeps its minSdkVersion 26 out of the manifest
+    // merge, so the module stays installable on API 24-25 with the de.robv entry point.
     compileOnly 'de.robv.android.xposed:api:53'
+    compileOnly 'io.github.libxposed:api:101.0.1'
 }

--- a/app/src/main/java/com/thinkdifferent/anywebview/AnyWebView.java
+++ b/app/src/main/java/com/thinkdifferent/anywebview/AnyWebView.java
@@ -2,251 +2,49 @@ package com.thinkdifferent.anywebview;
 
 import static com.thinkdifferent.anywebview.XposedHelpersWraper.findAndHookMethod;
 import static com.thinkdifferent.anywebview.XposedHelpersWraper.findClass;
-import static com.thinkdifferent.anywebview.XposedHelpersWraper.findConstructorBestMatch;
-import static com.thinkdifferent.anywebview.XposedHelpersWraper.getObjectField;
 import static com.thinkdifferent.anywebview.XposedHelpersWraper.log;
-
-import android.content.Context;
-import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager;
-import android.os.Bundle;
-import android.util.Base64;
-
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.lang.reflect.Array;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.security.cert.CertificateFactory;
-import java.security.cert.X509Certificate;
-import java.util.ArrayList;
-import java.util.List;
 
 import de.robv.android.xposed.XC_MethodHook;
 import de.robv.android.xposed.callbacks.XC_LoadPackage;
 
+/**
+ * Entry point for the original de.robv Xposed API, declared in assets/xposed_init.
+ *
+ * Kept alongside the libxposed entry point in AnyWebViewModule so the module keeps working on
+ * frameworks that do not implement libxposed, and on API 24-25, which libxposed does not support
+ * (its AAR declares minSdkVersion 26). Both adapters delegate to WebViewProviderInjector, which
+ * holds all of the actual logic.
+ */
 public class AnyWebView extends BaseXposedHookLoadPackage {
+
+    private final WebViewProviderInjector injector = new WebViewProviderInjector();
 
     @Override
     public void handleLoadPackage(XC_LoadPackage.LoadPackageParam lpparam) {
         //services.jar
-        if (lpparam.packageName.equals("android")) {
-            Initialize initialize = new Initialize(lpparam).invoke();
-            Class<?> classWebViewProviderInfo = initialize.getClassWebViewProviderInfo();
-            Class<?> classSystemImpl = initialize.getClassSystemImpl();
-            Constructor<?> constructorWebViewProviderInfo = initialize.getConstructorWebViewProviderInfo();
-
-            // getWebViewPackages() is called repeatedly (provider selection, package-change
-            // handling, shell commands). Enumerating every installed package on each call would
-            // run a full PackageManager sweep in system_server, so the appended entries are
-            // computed once and reused.
-            final Object[] extraProvidersCache = new Object[1];
-
-            findAndHookMethod(classSystemImpl, "getWebViewPackages", new XC_MethodHook() {
-                @Override
-                protected void afterHookedMethod(MethodHookParam param) {
-                    try {
-                        Object stockProviders = param.getResult();
-                        if (stockProviders == null) {
-                            return;
-                        }
-                        int stockLen = Array.getLength(stockProviders);
-                        if (extraProvidersCache[0] == null) {
-                            Context context = findSystemContext(param.thisObject, lpparam.classLoader);
-                            if (context == null) {
-                                log("no system Context, leaving provider list untouched");
-                                return;
-                            }
-                            PackageManager pm = context.getPackageManager();
-                            if (pm == null) {
-                                log("no PackageManager, leaving provider list untouched");
-                                return;
-                            }
-                            extraProvidersCache[0] = buildExtraProviders(
-                                    stockProviders, stockLen, pm,
-                                    classWebViewProviderInfo, constructorWebViewProviderInfo);
-                        }
-                        Object extraProviders = extraProvidersCache[0];
-                        int extraLen = Array.getLength(extraProviders);
-                        if (extraLen == 0) {
-                            return;
-                        }
-
-                        Object merged = Array.newInstance(classWebViewProviderInfo, stockLen + extraLen);
-                        System.arraycopy(stockProviders, 0, merged, 0, stockLen);
-                        System.arraycopy(extraProviders, 0, merged, stockLen, extraLen);
-                        log("appended " + extraLen + " provider(s) to " + stockLen + " stock entries");
-                        param.setResult(merged);
-                    } catch (Throwable t) {
-                        log(t);
-                    }
+        if (!lpparam.packageName.equals("android")) {
+            return;
+        }
+        final ClassLoader classLoader = lpparam.classLoader;
+        Class<?> classSystemImpl = findClass(
+                "com.android.server.webkit.SystemImpl", classLoader);
+        if (classSystemImpl == null) {
+            log("SystemImpl not found, nothing hooked");
+            return;
+        }
+        findAndHookMethod(classSystemImpl, "getWebViewPackages", new XC_MethodHook() {
+            @Override
+            protected void afterHookedMethod(MethodHookParam param) {
+                Object merged = injector.appendTo(
+                        param.thisObject, param.getResult(), classLoader);
+                if (merged != null) {
+                    param.setResult(merged);
                 }
-            });
-        }
+            }
+        });
     }
-
-    /**
-     * Resolves a system_server Context, which yields a PackageManager privileged enough to
-     * enumerate every installed package with signatures.
-     *
-     * On Android 15+ WebViewUpdateService constructs SystemImpl per service and it holds the
-     * Context in mContext, so the receiver is the most direct source and is exactly the
-     * PackageManager SystemImpl itself uses in getPackageInfoForProvider(). On API 24-34
-     * SystemImpl is a LazyHolder singleton with a no-arg constructor and no Context field at all
-     * (its SystemInterface methods take a Context parameter instead), so fall back to
-     * system_server's own ActivityThread, which is present on every release.
-     */
-    private static Context findSystemContext(Object systemImpl, ClassLoader classLoader) {
-        try {
-            Field field = systemImpl.getClass().getDeclaredField("mContext");
-            field.setAccessible(true);
-            Context context = (Context) field.get(systemImpl);
-            if (context != null) {
-                return context;
-            }
-        } catch (NoSuchFieldException expectedOnOlderReleases) {
-            // Pre-Android-15 SystemImpl has no Context field; handled by the fallback below.
-        } catch (Throwable t) {
-            log(t);
-        }
-        try {
-            Class<?> classActivityThread = Class.forName(
-                    "android.app.ActivityThread", false, classLoader);
-            Object activityThread = classActivityThread.getMethod("currentActivityThread")
-                    .invoke(null);
-            if (activityThread != null) {
-                return (Context) classActivityThread.getMethod("getSystemContext")
-                        .invoke(activityThread);
-            }
-        } catch (Throwable t) {
-            log(t);
-        }
-        return null;
-    }
-
-    /**
-     * Builds the WebViewProviderInfo[] to append: every installed package declaring
-     * com.android.webview.WebViewLibrary meta-data that is not already in the stock list.
-     *
-     * Packages without that meta-data are skipped because validityResult() rejects them with
-     * VALIDITY_NO_LIBRARY_FLAG regardless, so including them would only cost a PackageManager
-     * lookup each. Entries are marked availableByDefault so provider selection considers them,
-     * and carry their own signature so providerHasValidSignature() passes without relying on a
-     * debuggable build. Actual suitability is still decided downstream by validityResult().
-     */
-    private static Object buildExtraProviders(Object stockProviders, int stockLen,
-                                              PackageManager pm,
-                                              Class<?> classWebViewProviderInfo,
-                                              Constructor<?> constructorWebViewProviderInfo) throws Exception {
-        List<String> stockPkgNames = new ArrayList<>();
-        for (int i = 0; i < stockLen; i++) {
-            Object provider = Array.get(stockProviders, i);
-            stockPkgNames.add((String) getObjectField(provider, "packageName"));
-        }
-        log("stock providers:" + stockPkgNames);
-
-        List<PackageInfo> installedPackageInfoList = pm.getInstalledPackages(
-                PackageManager.MATCH_ALL | PackageManager.GET_META_DATA | PackageManager.GET_SIGNATURES);
-        if (installedPackageInfoList == null) {
-            log("installedPackageInfoList is null");
-            return Array.newInstance(classWebViewProviderInfo, 0);
-        }
-        log("installedPackageInfoList length:" + installedPackageInfoList.size());
-
-        List<Object> extras = new ArrayList<>();
-        for (PackageInfo packageInfo : installedPackageInfoList) {
-            if (packageInfo.applicationInfo == null) {
-                continue;
-            }
-            Bundle metaData = packageInfo.applicationInfo.metaData;
-            if (metaData == null) {
-                continue;
-            }
-            String awLib = metaData.getString("com.android.webview.WebViewLibrary");
-            if (awLib == null || awLib.isEmpty()) {
-                continue;
-            }
-            if (stockPkgNames.contains(packageInfo.packageName)) {
-                log("skipping already-declared provider:" + packageInfo.packageName);
-                continue;
-            }
-            if (packageInfo.signatures == null || packageInfo.signatures.length == 0) {
-                log("skipping unsigned provider:" + packageInfo.packageName);
-                continue;
-            }
-
-            String label = pm.getApplicationLabel(packageInfo.applicationInfo).toString();
-            String[] signatures = encodeSignatures(packageInfo);
-            log("adding provider:" + packageInfo.packageName + " label:" + label
-                    + " signatures:" + signatures.length);
-            extras.add(constructorWebViewProviderInfo.newInstance(
-                    packageInfo.packageName, label,
-                    /*availableByDefault*/ true, /*isFallback*/ false, signatures));
-        }
-
-        Object result = Array.newInstance(classWebViewProviderInfo, extras.size());
-        for (int i = 0; i < extras.size(); i++) {
-            Array.set(result, i, extras.get(i));
-        }
-        return result;
-    }
-
-    /**
-     * WebViewProviderInfo takes base64-encoded DER certificates, matching the format the
-     * framework parses out of config_webview_packages.xml.
-     */
-    private static String[] encodeSignatures(PackageInfo packageInfo) throws Exception {
-        int signsLen = packageInfo.signatures.length;
-        String[] signatures = new String[signsLen];
-        CertificateFactory certFactory = CertificateFactory.getInstance("X509");
-        for (int i = 0; i < signsLen; i++) {
-            InputStream certStream = new ByteArrayInputStream(packageInfo.signatures[i].toByteArray());
-            X509Certificate x509Cert = (X509Certificate) certFactory.generateCertificate(certStream);
-            signatures[i] = Base64.encodeToString(x509Cert.getEncoded(), Base64.NO_WRAP);
-        }
-        return signatures;
-    }
-
 
     @Override
     public void initZygote(StartupParam startupParam) {
-    }
-
-    private static class Initialize {
-        private XC_LoadPackage.LoadPackageParam lpparam;
-        private Class<?> classWebViewProviderInfo;
-        private Class<?> classSystemImpl;
-        private Constructor<?> constructorWebViewProviderInfo;
-
-        public Initialize(XC_LoadPackage.LoadPackageParam lpparam) {
-            this.lpparam = lpparam;
-        }
-
-        public Class<?> getClassWebViewProviderInfo() {
-            return classWebViewProviderInfo;
-        }
-
-        public Class<?> getClassSystemImpl() {
-            return classSystemImpl;
-        }
-
-        public Constructor<?> getConstructorWebViewProviderInfo() {
-            return constructorWebViewProviderInfo;
-        }
-
-
-        public Initialize invoke() {
-            log("invoke init");
-            classWebViewProviderInfo = findClass(
-                    "android.webkit.WebViewProviderInfo", lpparam.classLoader);
-            constructorWebViewProviderInfo = findConstructorBestMatch(
-                    classWebViewProviderInfo,/*packageName*/String.class,
-                    /*description*/String.class,/*TAG_AVAILABILITY*/boolean.class,
-                    /*TAG_FALLBACK*/boolean.class,/*readSignatures*/String[].class);
-
-            classSystemImpl = findClass("com.android.server.webkit.SystemImpl", lpparam.classLoader);
-
-            return this;
-        }
     }
 }

--- a/app/src/main/java/com/thinkdifferent/anywebview/AnyWebView.java
+++ b/app/src/main/java/com/thinkdifferent/anywebview/AnyWebView.java
@@ -17,7 +17,28 @@ import de.robv.android.xposed.callbacks.XC_LoadPackage;
  */
 public class AnyWebView extends BaseXposedHookLoadPackage {
 
-    private final WebViewProviderInjector injector = new WebViewProviderInjector();
+    private static final String VIA = "de.robv";
+
+    /** Vector surfaces android.util.Log from de.robv modules in logcat. */
+    private static final Logger LOGGER = new Logger() {
+        @Override
+        public void d(String message) {
+            log(message);
+        }
+
+        @Override
+        public void w(String message) {
+            log(message);
+        }
+
+        @Override
+        public void e(String message, Throwable t) {
+            log(message);
+            log(t);
+        }
+    };
+
+    private final WebViewProviderInjector injector = new WebViewProviderInjector(VIA, LOGGER);
 
     @Override
     public void handleLoadPackage(XC_LoadPackage.LoadPackageParam lpparam) {
@@ -29,9 +50,10 @@ public class AnyWebView extends BaseXposedHookLoadPackage {
         Class<?> classSystemImpl = findClass(
                 "com.android.server.webkit.SystemImpl", classLoader);
         if (classSystemImpl == null) {
-            log("SystemImpl not found, nothing hooked");
+            log(VIA + ": SystemImpl not found, nothing hooked");
             return;
         }
+        log(VIA + ": entry point loaded, hooking getWebViewPackages");
         findAndHookMethod(classSystemImpl, "getWebViewPackages", new XC_MethodHook() {
             @Override
             protected void afterHookedMethod(MethodHookParam param) {

--- a/app/src/main/java/com/thinkdifferent/anywebview/AnyWebViewModule.java
+++ b/app/src/main/java/com/thinkdifferent/anywebview/AnyWebViewModule.java
@@ -1,0 +1,48 @@
+package com.thinkdifferent.anywebview;
+
+import android.util.Log;
+
+import java.lang.reflect.Method;
+
+import io.github.libxposed.api.XposedInterface;
+import io.github.libxposed.api.XposedModule;
+import io.github.libxposed.api.XposedModuleInterface;
+
+/**
+ * Entry point for the libxposed API, declared in META-INF/xposed/java_init.list.
+ *
+ * The framework instantiates this through the no-arg constructor and then calls
+ * attachFramework(), so hook() is available from onSystemServerStarting() onwards.
+ *
+ * Compared with the de.robv adapter in AnyWebView this needs no package-name filtering:
+ * onSystemServerStarting() fires only for system_server, which is the sole process this module
+ * cares about. The interceptor model also expresses the append directly -- proceed(), then return
+ * a longer array -- rather than mutating a result out of band.
+ */
+public class AnyWebViewModule extends XposedModule {
+
+    private static final String TAG = "anywebview";
+
+    private final WebViewProviderInjector injector = new WebViewProviderInjector();
+
+    @Override
+    public void onSystemServerStarting(XposedModuleInterface.SystemServerStartingParam param) {
+        final ClassLoader classLoader = param.getClassLoader();
+        try {
+            Class<?> classSystemImpl = classLoader.loadClass(
+                    "com.android.server.webkit.SystemImpl");
+            Method getWebViewPackages = classSystemImpl.getDeclaredMethod("getWebViewPackages");
+            hook(getWebViewPackages).intercept(new XposedInterface.Hooker() {
+                @Override
+                public Object intercept(XposedInterface.Chain chain) throws Throwable {
+                    Object stockProviders = chain.proceed();
+                    Object merged = injector.appendTo(
+                            chain.getThisObject(), stockProviders, classLoader);
+                    return merged != null ? merged : stockProviders;
+                }
+            });
+        } catch (Throwable t) {
+            Log.e(TAG, "failed to hook SystemImpl.getWebViewPackages", t);
+        }
+    }
+}

--- a/app/src/main/java/com/thinkdifferent/anywebview/AnyWebViewModule.java
+++ b/app/src/main/java/com/thinkdifferent/anywebview/AnyWebViewModule.java
@@ -22,13 +22,38 @@ import io.github.libxposed.api.XposedModuleInterface;
 public class AnyWebViewModule extends XposedModule {
 
     private static final String TAG = "anywebview";
+    private static final String VIA = "libxposed";
 
-    private final WebViewProviderInjector injector = new WebViewProviderInjector();
+    /**
+     * Routes through XposedInterface.log() rather than android.util.Log: Vector does not surface
+     * android.util.Log from libxposed modules, so the latter is silently dropped.
+     */
+    private final Logger logger = new Logger() {
+        @Override
+        public void d(String message) {
+            log(Log.DEBUG, TAG, message);
+        }
+
+        @Override
+        public void w(String message) {
+            log(Log.WARN, TAG, message);
+        }
+
+        @Override
+        public void e(String message, Throwable t) {
+            log(Log.ERROR, TAG, message, t);
+        }
+    };
+
+    private final WebViewProviderInjector injector = new WebViewProviderInjector(VIA, logger);
 
     @Override
     public void onSystemServerStarting(XposedModuleInterface.SystemServerStartingParam param) {
         final ClassLoader classLoader = param.getClassLoader();
         try {
+            logger.d(VIA + ": entry point loaded (framework=" + getFrameworkName()
+                    + " " + getFrameworkVersion() + ", api=" + getApiVersion()
+                    + "), hooking getWebViewPackages");
             Class<?> classSystemImpl = classLoader.loadClass(
                     "com.android.server.webkit.SystemImpl");
             Method getWebViewPackages = classSystemImpl.getDeclaredMethod("getWebViewPackages");
@@ -42,7 +67,7 @@ public class AnyWebViewModule extends XposedModule {
                 }
             });
         } catch (Throwable t) {
-            Log.e(TAG, "failed to hook SystemImpl.getWebViewPackages", t);
+            logger.e(VIA + ": failed to hook SystemImpl.getWebViewPackages", t);
         }
     }
 }

--- a/app/src/main/java/com/thinkdifferent/anywebview/Logger.java
+++ b/app/src/main/java/com/thinkdifferent/anywebview/Logger.java
@@ -1,0 +1,22 @@
+package com.thinkdifferent.anywebview;
+
+/**
+ * Log sink supplied by whichever entry point is active.
+ *
+ * The two frameworks do not share a log channel. Vector surfaces android.util.Log from de.robv
+ * modules in logcat, but not from libxposed modules -- those are expected to use
+ * XposedInterface.log(), which routes into the framework's own module log. Hardcoding
+ * android.util.Log therefore left the module completely silent under libxposed: working, but with
+ * no diagnostics and no error reporting.
+ *
+ * WebViewProviderInjector logs through this instead, so each adapter can route to the channel its
+ * framework actually reads.
+ */
+public interface Logger {
+
+    void d(String message);
+
+    void w(String message);
+
+    void e(String message, Throwable t);
+}

--- a/app/src/main/java/com/thinkdifferent/anywebview/WebViewProviderInjector.java
+++ b/app/src/main/java/com/thinkdifferent/anywebview/WebViewProviderInjector.java
@@ -5,7 +5,6 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.util.Base64;
-import android.util.Log;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -28,11 +27,20 @@ import java.util.List;
  */
 public final class WebViewProviderInjector {
 
-    private static final String TAG = "anywebview";
     private static final String WEBVIEW_LIBRARY_META_DATA = "com.android.webview.WebViewLibrary";
+
+    /** Which entry point owns this instance, for log attribution. */
+    private final String via;
+    /** Framework-appropriate log sink, supplied by the entry point. */
+    private final Logger logger;
 
     private Class<?> classWebViewProviderInfo;
     private Object extraProviders;
+
+    public WebViewProviderInjector(String via, Logger logger) {
+        this.via = via;
+        this.logger = logger;
+    }
 
     /**
      * Returns a WebViewProviderInfo[] consisting of stockProviders plus every installed provider
@@ -56,12 +64,12 @@ public final class WebViewProviderInjector {
             if (extraProviders == null) {
                 Context context = findSystemContext(systemImpl, classLoader);
                 if (context == null) {
-                    Log.w(TAG, "no system Context, leaving provider list untouched");
+                    logger.w(via + ": no system Context, leaving provider list untouched");
                     return null;
                 }
                 PackageManager pm = context.getPackageManager();
                 if (pm == null) {
-                    Log.w(TAG, "no PackageManager, leaving provider list untouched");
+                    logger.w(via + ": no PackageManager, leaving provider list untouched");
                     return null;
                 }
                 classWebViewProviderInfo = classLoader.loadClass("android.webkit.WebViewProviderInfo");
@@ -80,10 +88,10 @@ public final class WebViewProviderInjector {
             Object merged = Array.newInstance(classWebViewProviderInfo, stockLen + extraLen);
             System.arraycopy(stockProviders, 0, merged, 0, stockLen);
             System.arraycopy(extraProviders, 0, merged, stockLen, extraLen);
-            Log.d(TAG, "appended " + extraLen + " provider(s) to " + stockLen + " stock entries");
+            logger.d(via + ": appended " + extraLen + " provider(s) to " + stockLen + " stock entries");
             return merged;
         } catch (Throwable t) {
-            Log.e(TAG, "failed to append WebView providers", t);
+            logger.e(via + ": failed to append WebView providers", t);
             return null;
         }
     }
@@ -99,7 +107,7 @@ public final class WebViewProviderInjector {
      * (its SystemInterface methods take a Context parameter instead), so fall back to
      * system_server's own ActivityThread, which is present on every release.
      */
-    private static Context findSystemContext(Object systemImpl, ClassLoader classLoader) {
+    private Context findSystemContext(Object systemImpl, ClassLoader classLoader) {
         if (systemImpl != null) {
             try {
                 Field field = systemImpl.getClass().getDeclaredField("mContext");
@@ -111,7 +119,7 @@ public final class WebViewProviderInjector {
             } catch (NoSuchFieldException expectedOnOlderReleases) {
                 // Pre-Android-15 SystemImpl has no Context field; handled by the fallback below.
             } catch (Throwable t) {
-                Log.w(TAG, "could not read SystemImpl.mContext", t);
+                logger.e(via + ": could not read SystemImpl.mContext", t);
             }
         }
         try {
@@ -124,7 +132,7 @@ public final class WebViewProviderInjector {
                         .invoke(activityThread);
             }
         } catch (Throwable t) {
-            Log.w(TAG, "could not reach ActivityThread system context", t);
+            logger.e(via + ": could not reach ActivityThread system context", t);
         }
         return null;
     }
@@ -147,16 +155,16 @@ public final class WebViewProviderInjector {
         for (int i = 0; i < stockLen; i++) {
             stockPkgNames.add((String) packageNameField.get(Array.get(stockProviders, i)));
         }
-        Log.d(TAG, "stock providers:" + stockPkgNames);
+        logger.d(via + ": stock providers:" + stockPkgNames);
 
         List<PackageInfo> installedPackageInfoList = pm.getInstalledPackages(
                 PackageManager.MATCH_ALL | PackageManager.GET_META_DATA
                         | PackageManager.GET_SIGNATURES);
         if (installedPackageInfoList == null) {
-            Log.w(TAG, "installedPackageInfoList is null");
+            logger.w(via + ": installedPackageInfoList is null");
             return Array.newInstance(classWebViewProviderInfo, 0);
         }
-        Log.d(TAG, "installedPackageInfoList length:" + installedPackageInfoList.size());
+        logger.d(via + ": installedPackageInfoList length:" + installedPackageInfoList.size());
 
         List<Object> extras = new ArrayList<>();
         for (PackageInfo packageInfo : installedPackageInfoList) {
@@ -172,17 +180,17 @@ public final class WebViewProviderInjector {
                 continue;
             }
             if (stockPkgNames.contains(packageInfo.packageName)) {
-                Log.d(TAG, "skipping already-declared provider:" + packageInfo.packageName);
+                logger.d(via + ": skipping already-declared provider:" + packageInfo.packageName);
                 continue;
             }
             if (packageInfo.signatures == null || packageInfo.signatures.length == 0) {
-                Log.d(TAG, "skipping unsigned provider:" + packageInfo.packageName);
+                logger.d(via + ": skipping unsigned provider:" + packageInfo.packageName);
                 continue;
             }
 
             String label = pm.getApplicationLabel(packageInfo.applicationInfo).toString();
             String[] signatures = encodeSignatures(packageInfo);
-            Log.d(TAG, "adding provider:" + packageInfo.packageName + " label:" + label
+            logger.d(via + ": adding provider:" + packageInfo.packageName + " label:" + label
                     + " signatures:" + signatures.length);
             extras.add(constructorWebViewProviderInfo.newInstance(
                     packageInfo.packageName, label,

--- a/app/src/main/java/com/thinkdifferent/anywebview/WebViewProviderInjector.java
+++ b/app/src/main/java/com/thinkdifferent/anywebview/WebViewProviderInjector.java
@@ -1,0 +1,214 @@
+package com.thinkdifferent.anywebview;
+
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+import android.util.Base64;
+import android.util.Log;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.lang.reflect.Array;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Framework-agnostic core of the module: given the WebViewProviderInfo[] that
+ * SystemImpl.getWebViewPackages() returned, produce a longer array with every installed WebView
+ * provider appended.
+ *
+ * This class deliberately has no Xposed dependency of any kind, so the same logic backs both the
+ * de.robv (assets/xposed_init) and libxposed (META-INF/xposed/java_init.list) entry points. Each
+ * entry point owns exactly one instance, and therefore one cache.
+ */
+public final class WebViewProviderInjector {
+
+    private static final String TAG = "anywebview";
+    private static final String WEBVIEW_LIBRARY_META_DATA = "com.android.webview.WebViewLibrary";
+
+    private Class<?> classWebViewProviderInfo;
+    private Object extraProviders;
+
+    /**
+     * Returns a WebViewProviderInfo[] consisting of stockProviders plus every installed provider
+     * not already present, or null when there is nothing to add or anything went wrong. Callers
+     * substitute the returned array for the hooked method's result; returning null means "leave
+     * the original result alone".
+     *
+     * @param systemImpl  the SystemImpl instance the hooked call was made on
+     * @param classLoader the system_server class loader
+     */
+    public Object appendTo(Object systemImpl, Object stockProviders, ClassLoader classLoader) {
+        try {
+            if (stockProviders == null) {
+                return null;
+            }
+            int stockLen = Array.getLength(stockProviders);
+
+            // getWebViewPackages() is called repeatedly (provider selection, package-change
+            // handling, shell commands). Enumerating every installed package on each call would
+            // run a full PackageManager sweep in system_server, so this is computed once.
+            if (extraProviders == null) {
+                Context context = findSystemContext(systemImpl, classLoader);
+                if (context == null) {
+                    Log.w(TAG, "no system Context, leaving provider list untouched");
+                    return null;
+                }
+                PackageManager pm = context.getPackageManager();
+                if (pm == null) {
+                    Log.w(TAG, "no PackageManager, leaving provider list untouched");
+                    return null;
+                }
+                classWebViewProviderInfo = classLoader.loadClass("android.webkit.WebViewProviderInfo");
+                Constructor<?> constructor = classWebViewProviderInfo.getConstructor(
+                        /*packageName*/ String.class, /*description*/ String.class,
+                        /*availableByDefault*/ boolean.class, /*isFallback*/ boolean.class,
+                        /*signatures*/ String[].class);
+                extraProviders = buildExtraProviders(stockProviders, stockLen, pm, constructor);
+            }
+
+            int extraLen = Array.getLength(extraProviders);
+            if (extraLen == 0) {
+                return null;
+            }
+
+            Object merged = Array.newInstance(classWebViewProviderInfo, stockLen + extraLen);
+            System.arraycopy(stockProviders, 0, merged, 0, stockLen);
+            System.arraycopy(extraProviders, 0, merged, stockLen, extraLen);
+            Log.d(TAG, "appended " + extraLen + " provider(s) to " + stockLen + " stock entries");
+            return merged;
+        } catch (Throwable t) {
+            Log.e(TAG, "failed to append WebView providers", t);
+            return null;
+        }
+    }
+
+    /**
+     * Resolves a system_server Context, which yields a PackageManager privileged enough to
+     * enumerate every installed package with signatures.
+     *
+     * On Android 15+ WebViewUpdateService constructs SystemImpl per service and it holds the
+     * Context in mContext, so the receiver is the most direct source and is exactly the
+     * PackageManager SystemImpl itself uses in getPackageInfoForProvider(). On API 24-34
+     * SystemImpl is a LazyHolder singleton with a no-arg constructor and no Context field at all
+     * (its SystemInterface methods take a Context parameter instead), so fall back to
+     * system_server's own ActivityThread, which is present on every release.
+     */
+    private static Context findSystemContext(Object systemImpl, ClassLoader classLoader) {
+        if (systemImpl != null) {
+            try {
+                Field field = systemImpl.getClass().getDeclaredField("mContext");
+                field.setAccessible(true);
+                Context context = (Context) field.get(systemImpl);
+                if (context != null) {
+                    return context;
+                }
+            } catch (NoSuchFieldException expectedOnOlderReleases) {
+                // Pre-Android-15 SystemImpl has no Context field; handled by the fallback below.
+            } catch (Throwable t) {
+                Log.w(TAG, "could not read SystemImpl.mContext", t);
+            }
+        }
+        try {
+            Class<?> classActivityThread = Class.forName(
+                    "android.app.ActivityThread", false, classLoader);
+            Object activityThread = classActivityThread.getMethod("currentActivityThread")
+                    .invoke(null);
+            if (activityThread != null) {
+                return (Context) classActivityThread.getMethod("getSystemContext")
+                        .invoke(activityThread);
+            }
+        } catch (Throwable t) {
+            Log.w(TAG, "could not reach ActivityThread system context", t);
+        }
+        return null;
+    }
+
+    /**
+     * Builds the WebViewProviderInfo[] to append: every installed package declaring
+     * com.android.webview.WebViewLibrary meta-data that is not already in the stock list.
+     *
+     * Packages without that meta-data are skipped because validityResult() rejects them with
+     * VALIDITY_NO_LIBRARY_FLAG regardless, so including them would only cost a PackageManager
+     * lookup each. Entries are marked availableByDefault so provider selection considers them,
+     * and carry their own signature so providerHasValidSignature() passes without relying on a
+     * debuggable build. Actual suitability is still decided downstream by validityResult().
+     */
+    private Object buildExtraProviders(Object stockProviders, int stockLen, PackageManager pm,
+                                       Constructor<?> constructorWebViewProviderInfo)
+            throws Exception {
+        List<String> stockPkgNames = new ArrayList<>();
+        Field packageNameField = classWebViewProviderInfo.getField("packageName");
+        for (int i = 0; i < stockLen; i++) {
+            stockPkgNames.add((String) packageNameField.get(Array.get(stockProviders, i)));
+        }
+        Log.d(TAG, "stock providers:" + stockPkgNames);
+
+        List<PackageInfo> installedPackageInfoList = pm.getInstalledPackages(
+                PackageManager.MATCH_ALL | PackageManager.GET_META_DATA
+                        | PackageManager.GET_SIGNATURES);
+        if (installedPackageInfoList == null) {
+            Log.w(TAG, "installedPackageInfoList is null");
+            return Array.newInstance(classWebViewProviderInfo, 0);
+        }
+        Log.d(TAG, "installedPackageInfoList length:" + installedPackageInfoList.size());
+
+        List<Object> extras = new ArrayList<>();
+        for (PackageInfo packageInfo : installedPackageInfoList) {
+            if (packageInfo.applicationInfo == null) {
+                continue;
+            }
+            Bundle metaData = packageInfo.applicationInfo.metaData;
+            if (metaData == null) {
+                continue;
+            }
+            String awLib = metaData.getString(WEBVIEW_LIBRARY_META_DATA);
+            if (awLib == null || awLib.isEmpty()) {
+                continue;
+            }
+            if (stockPkgNames.contains(packageInfo.packageName)) {
+                Log.d(TAG, "skipping already-declared provider:" + packageInfo.packageName);
+                continue;
+            }
+            if (packageInfo.signatures == null || packageInfo.signatures.length == 0) {
+                Log.d(TAG, "skipping unsigned provider:" + packageInfo.packageName);
+                continue;
+            }
+
+            String label = pm.getApplicationLabel(packageInfo.applicationInfo).toString();
+            String[] signatures = encodeSignatures(packageInfo);
+            Log.d(TAG, "adding provider:" + packageInfo.packageName + " label:" + label
+                    + " signatures:" + signatures.length);
+            extras.add(constructorWebViewProviderInfo.newInstance(
+                    packageInfo.packageName, label,
+                    /*availableByDefault*/ true, /*isFallback*/ false, signatures));
+        }
+
+        Object result = Array.newInstance(classWebViewProviderInfo, extras.size());
+        for (int i = 0; i < extras.size(); i++) {
+            Array.set(result, i, extras.get(i));
+        }
+        return result;
+    }
+
+    /**
+     * WebViewProviderInfo takes base64-encoded DER certificates, matching the format the
+     * framework parses out of config_webview_packages.xml.
+     */
+    private static String[] encodeSignatures(PackageInfo packageInfo) throws Exception {
+        int signsLen = packageInfo.signatures.length;
+        String[] signatures = new String[signsLen];
+        CertificateFactory certFactory = CertificateFactory.getInstance("X509");
+        for (int i = 0; i < signsLen; i++) {
+            InputStream certStream = new ByteArrayInputStream(packageInfo.signatures[i].toByteArray());
+            X509Certificate x509Cert = (X509Certificate) certFactory.generateCertificate(certStream);
+            signatures[i] = Base64.encodeToString(x509Cert.getEncoded(), Base64.NO_WRAP);
+        }
+        return signatures;
+    }
+}

--- a/app/src/main/resources/META-INF/xposed/java_init.list
+++ b/app/src/main/resources/META-INF/xposed/java_init.list
@@ -1,0 +1,1 @@
+com.thinkdifferent.anywebview.AnyWebViewModule

--- a/app/src/main/resources/META-INF/xposed/module.prop
+++ b/app/src/main/resources/META-INF/xposed/module.prop
@@ -1,0 +1,2 @@
+minApiVersion=101
+targetApiVersion=101

--- a/app/src/main/resources/META-INF/xposed/scope.list
+++ b/app/src/main/resources/META-INF/xposed/scope.list
@@ -1,0 +1,1 @@
+android


### PR DESCRIPTION
# This PR was vibe coded, but an human tested what it could. Feels free to close this if this is too much a burden to review. See bottom to know what was really tested

Closes #28

Adds a second entry point so the module runs on the libxposed API
(`io.github.libxposed:api:101.0.1`) as well as the original `de.robv` one,
without dropping anything.

**Stacks on #29** — it branches from that fix, so only the last two commits are
new here. Best reviewed after #29, or with #29 as the base.

**Why both instead of migrating:** `de.robv.android.xposed:api` has been
unmaintained since 2016 (it stops at version 82, published 2016-04-15). Modern
frameworks implement libxposed natively and service the old API through a legacy
shim. But migrating outright would drop every framework that does not implement
libxposed. So: ship both entry points, share all the logic.

```
assets/xposed_init             -> AnyWebView        (de.robv)
META-INF/xposed/java_init.list -> AnyWebViewModule  (libxposed)
                                  |
                          WebViewProviderInjector   <- all logic, zero Xposed deps
```

`AnyWebView` drops from 258 lines to 48. `minSdk` stays 24.

**Two things only showed up on a device**, both of which would have shipped
silently broken:

1. **The libxposed entry point was never loaded.** Vector picks one strategy
   exclusively, gated on `targetApiVersion` in `META-INF/xposed/module.prop` —
   which the APK did not ship, so it always fell through to legacy. Every
   "dual" build was quietly running legacy-only.
2. **The module was silent under libxposed.** `android.util.Log` is dropped for
   modern modules; they are expected to use `XposedInterface.log()`. It worked,
   but produced no diagnostics and no error reporting at all.

**Verified on Android 16 (API 36) / Vector v2.0 (3044):** each entry point was
tested in isolation by building with only one registration file present, and
both inject correctly.

### Not tested

**Only Vector was tested.** Classic Xposed, EdXposed and LSPosed proper were not
exercised at all. The de.robv path is unchanged in behaviour from #29, so it
should be no worse than before, but "should" is doing work in that sentence.

**The double-hook guard is unreachable on Vector and therefore untested.**
Because Vector's strategy is exclusive, both entry points can never load
together there, so the scenario the dedupe protects against cannot occur. It
remains a guard for frameworks that might behave differently — unverified.

**The API 24-34 fallback path is still untested**, unchanged from #29. libxposed
itself declares `minSdkVersion 26`, but that does not reach the manifest (see
below), so the de.robv path still covers 24-25 in principle.

### Also included

- `Logger`, supplied by whichever entry point is active, so each adapter logs
  through the channel its framework actually reads.
- `META-INF/xposed/scope.list` naming the system framework.

<details>
<summary><b>Details:</b> why dual, framework findings, architecture, test output</summary>

## Why dual rather than a migration

Three options were considered:

| option | cost |
|---|---|
| Full migration to libxposed | loses every framework without libxposed support |
| **Dual entry point** | more entry-point surface, shared core |
| Stay on de.robv only | no functional loss today, but builds on a 2016 API |

The blocker that initially looked fatal was libxposed's AAR manifest:

```xml
<uses-sdk android:minSdkVersion="26" />
```

That would have forced `minSdk` 24 -> 26. It turns out `compileOnly` avoids it
entirely: the AAR never enters the runtime graph, so its manifest never enters
the merge. Both APIs are provided by the framework at runtime anyway. The
packaged APK still reports `minSdkVersion 24` — verified with `aapt2`.

## Framework finding 1: strategy selection is exclusive

From `daemon/.../data/FileSystem.kt` in the Vector source:

```kotlin
val targetApi = props["targetApiVersion"]?.toIntOrNull() ?: 0
val hasLegacyFile = zip.getEntry("assets/xposed_init") != null

val strategy = when {
  targetApi >= 101 -> "MODERN"        // META-INF/xposed/java_init.list
  hasLegacyFile    -> "LEGACY"        // assets/xposed_init
  targetApi == 100 -> "UNSUPPORTED"   // API 100 is dropped
  else -> "NONE"
}
```

`targetApi` comes from `META-INF/xposed/module.prop`. Without that file it is
`0`, so a module shipping both entry points still resolves to `LEGACY`. Adding
`module.prop` with `minApiVersion`/`targetApiVersion` 101 is what actually
enables the modern path.

Because the selection is exclusive, double-hooking cannot occur on this
framework.

## Framework finding 2: modern modules need `XposedInterface.log()`

Vector surfaces `android.util.Log` from `de.robv` modules in logcat, but drops it
from libxposed modules. The injector originally hardcoded `android.util.Log`,
which left the modern path completely silent — it injected correctly while
reporting nothing, including on failure.

`Logger` is now supplied by the active entry point: the de.robv adapter keeps
`android.util.Log`, the libxposed adapter routes to `XposedInterface.log()`.

## Architecture

`WebViewProviderInjector` holds all logic and has no Xposed dependency of any
kind. Each adapter only locates `SystemImpl.getWebViewPackages()`, installs a
hook, and hands the result over. Each owns one injector instance, and therefore
one cache.

The libxposed adapter is the simpler of the two. `onSystemServerStarting()`
fires only for system_server, so no package-name filtering is needed, and the
interceptor model expresses the append directly rather than mutating a result
out of band:

```java
Object stockProviders = chain.proceed();
Object merged = injector.appendTo(chain.getThisObject(), stockProviders, classLoader);
return merged != null ? merged : stockProviders;
```

## Test output

Vector's own log confirms which class it loaded — note another installed module
on the same boot taking the legacy path, for contrast:

```
V/VectorLegacyBridge   Loading legacy module com.coderstory.toolkit from /data/app/...
D/VectorModuleManager  Loading module com.thinkdifferent.anywebview
V/VectorModuleManager  Loading class class com.thinkdifferent.anywebview.AnyWebViewModule
D/VectorModuleManager  Loaded module com.thinkdifferent.anywebview successfully.
```

With the `Logger` fix, the modern path reports itself — one append per call,
two calls here:

```
D anywebview: com.thinkdifferent.anywebview: libxposed: appended 1 provider(s) to 6 stock entries
D anywebview: com.thinkdifferent.anywebview: libxposed: appended 1 provider(s) to 6 stock entries
```

Each entry point was then validated alone, by building with only one
registration file present:

| build | entry point in APK | result |
|---|---|---|
| no `module.prop` | `assets/xposed_init` only | `de.robv: appended 1 provider(s) to 6 stock entries` |
| no `assets/xposed_init` | `META-INF/xposed/*` only | provider injected, reported `Valid` |

The modern-only run was verified through `dumpsys` rather than logs, because
`dumpAllPackageInformationLocked()` calls `mSystemInterface.getWebViewPackages()`:

```java
WebViewProviderInfo[] allProviders = mSystemInterface.getWebViewPackages();
pw.println("  WebView packages:");
```

so the provider could only appear if the hook ran — and the legacy adapter was
physically absent from that APK.

Packaging was checked with `aapt2` on the signed APK: both entry points present,
`minSdkVersion 24`, and no libxposed classes bundled (only unresolved type
references, provided by the framework at runtime).

</details>
