### PR TITLE
Fix `scope.list` to recommend the correct LSPosed scope.

### DIFF
--- a/app/src/main/resources/META-INF/xposed/scope.list
+++ b/app/src/main/resources/META-INF/xposed/scope.list
@@ -1,1 +1,1 @@
-android
+system


### PR DESCRIPTION
## Problem

`scope.list` contained `android`, which in LSPosed maps to the "Android System" scope — processes holding the shared `android` UID (e.g. `android.ui`). The module actually hooks `SystemImpl.getWebViewPackages()` which runs in `system_server` — the "System Framework" scope in LSPosed, mapped to `system`. LSPosed separates these two for finer-grained scope control.

This mismatch causes LSPosed to recommend checking the wrong scope. Users had to manually switch to "System Framework" for the module to work, as currently documented in the README.

## Fix

Change the single line in `scope.list` from `android` to `system`.

## Scope mapping

| scope.list value | LSPosed display name   | Actual target          |
|------------------|------------------------|------------------------|
| `android`        | Android System         | `android` shared-UID processes (e.g. `android.ui`) |
| `system`         | System Framework       | `system_server`        |

The module hooks are already correct (`AnyWebView.java` filters on `"android"` for the de.robv API where `system_server` is identified by that package name; `AnyWebViewModule.java` uses `onSystemServerStarting()` in the libxposed API). Only the metadata file was wrong.

## Note

`scope.list` only affects LSPosed's scope recommendation UI. Legacy de.robv frameworks do not read this file.
